### PR TITLE
Simple SSO login

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
           command: yarn run build
       - run:
           name: Run the site server
-          command: ./entrypoint 0.0.0.0:80
+          command: SECRET_KEY=secret_key ./entrypoint 0.0.0.0:80
           background: true
       - run:
           name: Check site is accessible
@@ -37,7 +37,7 @@ jobs:
           command: pip3 install -r requirements.txt
       - run:
           name: Start development server
-          command: ./entrypoint 0.0.0.0:80
+          command: SECRET_KEY=secret_key ./entrypoint 0.0.0.0:80
           background: true
       - run:
           name: Wait for development server
@@ -72,7 +72,7 @@ jobs:
       - run:
           name: Run tests with coverage
           command: |
-            coverage run  --source=. -m unittest discover tests
+            SECRET_KEY=secret_key coverage run  --source=. -m unittest discover tests
             bash <(curl -s https://codecov.io/bash) -cF python
 workflows:
   version: 2

--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 PORT=8043
 FLASK_DEBUG=true
+SECRET_KEY=secret_key

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 canonicalwebteam.flask-base==0.3.3
+Flask-OpenID-Stateless==1.2.6

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -53,8 +53,12 @@
       </div>
     </div>
   </header>
-  <!-- Add navigation below -->
-  <nav>This is the navigation</nav>
+  {% if not session['openid'] %}
+    <a type="button" href="/login">Login to view demo</a>
+  {% else %}
+    <a type="button" href="/logout">You are logged in, please log out</a>
+  {% endif %}
+
   <main>
     <!-- Add main content below -->
     {% block content %} {% endblock %}

--- a/templates/demo.html
+++ b/templates/demo.html
@@ -1,0 +1,2 @@
+<h1>DEMO PAGE</h1>
+<a type="button" href="/">Go back to Home page</a>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -26,6 +26,25 @@ class TestRoutes(unittest.TestCase):
 
         self.assertEqual(self.client.get("/not-found-url").status_code, 404)
 
+    def test_demo_no_session(self):
+        """
+        Demo page should redirect to login if no session.
+        """
+        response = self.client.get("/demo")
+        self.assertEqual(self.client.get("/demo").status_code, 302)
+        self.assertEqual(
+            response.location, "http://localhost/login?next=/demo"
+        )
+
+    def test_demo_login(self):
+        """
+        Demo page should be accessible if openid in session not empty.
+        """
+        with self.client.session_transaction() as s:
+            s["openid"] = "openid"
+        response = self.client.get("/demo")
+        self.assertEqual(response.status_code, 200)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,7 +1,14 @@
-from canonicalwebteam.flask_base.app import FlaskBase
-from flask import render_template
+import functools
+import os
 
-# Rename your project below
+import flask
+
+from canonicalwebteam.flask_base.app import FlaskBase
+from flask_openid import OpenID
+
+
+LOGIN_URL = "https://login.ubuntu.com"
+
 app = FlaskBase(
     __name__,
     "anbox-cloud.io",
@@ -11,7 +18,60 @@ app = FlaskBase(
     template_500="500.html",
 )
 
+app.secret_key = os.environ["SECRET_KEY"]
+open_id = OpenID(stateless=True, safe_roots=[])
+
+
+def login_required(func):
+    """
+    Decorator that checks if a user is logged in, and redirects
+    to login page if not.
+    """
+
+    @functools.wraps(func)
+    def is_user_logged_in(*args, **kwargs):
+        if "openid" not in flask.session:
+            return flask.redirect("/login?next=" + flask.request.path)
+
+        return func(*args, **kwargs)
+
+    return is_user_logged_in
+
 
 @app.route("/")
 def index():
-    return render_template("index.html")
+    return flask.render_template("index.html")
+
+
+@open_id.after_login
+def after_login(resp):
+    flask.session["openid"] = {
+        "identity_url": resp.identity_url,
+        "email": resp.email,
+    }
+    return flask.redirect(open_id.get_next_url())
+
+
+@app.route("/logout")
+def logout():
+    """
+    Empty the session, used to logout.
+    """
+    flask.session.pop("openid", None)
+
+    return flask.redirect(open_id.get_next_url())
+
+
+@app.route("/login", methods=["GET", "POST"])
+@open_id.loginhandler
+def login_handler():
+    if "openid" in flask.session:
+        return flask.redirect(open_id.get_next_url())
+
+    return open_id.try_login(LOGIN_URL, ask_for=["email"])
+
+
+@app.route("/demo")
+@login_required
+def demo():
+    return flask.render_template("demo.html")


### PR DESCRIPTION
## Done

Simple SSO login using engage.canonical.com as a base.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- To run tests: `./run test-python`
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Two ways to view the functionality:
  - Use the buttons log in and log out
  - Type in the browser `/login` and `/logout` to logout once you are logged in.

## Issue / Card

Ongoing #3 