### PR TITLE
Use subset of ubuntu font

### DIFF
--- a/static/sass/_settings.scss
+++ b/static/sass/_settings.scss
@@ -1,1 +1,2 @@
 $ubuntu-orange: #e95420;
+$font-use-subset-latin: true;


### PR DESCRIPTION
## Done

add variable to use the subset latin ubuntu fonts rather than the full set

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Open the inspector and see that the subset fonts are loading


## Issue / Card

Fixes #26

## Screenshots

![image](https://user-images.githubusercontent.com/441217/72740245-f68c6b00-3bad-11ea-96ec-27d10f2e51d3.png)
