### PR TITLE
Added vertical height to h3s

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -39,7 +39,7 @@
     <ul class="p-matrix p-matrix--two-col">
       <li class="p-matrix__item">
         <div class="p-matrix__content">
-          <h3>Game streaming</h3>
+          <h3 class="u-sv1">Game streaming</h3>
           <div class="p-matrix__desc">
             <ul class="p-list">
               <li class="p-list__item is-ticked">Better unit economics, thanks to high container density</li>
@@ -52,7 +52,7 @@
       </li>
       <li class="p-matrix__item">
         <div class="p-matrix__content">
-          <h3>Virtual devices</h3>
+          <h3 class="u-sv1">Virtual devices</h3>
           <div class="p-matrix__desc">
             <ul class="p-list">
               <li class="p-list__item is-ticked">Virtual live smartphone instances in the cloud</li>
@@ -65,7 +65,7 @@
       </li>
       <li class="p-matrix__item">
         <div class="p-matrix__content">
-          <h3>Enterprise mobile applications</h3>
+          <h3 class="u-sv1">Enterprise mobile applications</h3>
           <div class="p-matrix__desc">
             <ul class="p-list">
               <li class="p-list__item is-ticked">Delivery of on-premise mobile applications</li>
@@ -78,7 +78,7 @@
       </li>
       <li class="p-matrix__item">
         <div class="p-matrix__content">
-          <h3>Application testing</h3>
+          <h3 class="u-sv1">Application testing</h3>
           <div class="p-matrix__desc">
             <ul class="p-list">
               <li class="p-list__item is-ticked">Emulate thousands of different Android devices</li>


### PR DESCRIPTION
## Done

Added .u-sv1 to h3s to give more height on small screens

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Look on small sizes that there is better whitespace in the 'What you can do with Anbox Cloud' section


## Issue / Card

Fixes #27 

## Screenshots

[if relevant, include a screenshot]
![image](https://user-images.githubusercontent.com/441217/72740866-3869e100-3baf-11ea-9e09-0626b89db0ca.png)
