### PR TITLE
Copy update on home page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
 
 {% block description %}Anbox Cloud is the mobile cloud computing platform delivered by Canonical. Run Android in the cloud, at high scale and on any type of hardware. Canonical partners with cloud providers and computing hardware manufacturers to accelerate your time to market and provide long term commercial support.{% endblock %}
 
-{% block copydoc %}https://docs.google.com/document/d/1m3hL6Y8VqFqeZLy-sewPAyCZz-uGr7zfqzNwtGumyho/edit#{% endblock %}
+{% block copydoc %}https://docs.google.com/document/d/1SfpOBeDJUZj2ZYq4V8lHOUbQF9Yzo7mp5NajJDVwFMI/edit{% endblock %}
 
 {% block content %}
 {% include "/secondary-nav.html" %}
@@ -13,7 +13,7 @@
     <div class="col-6">
       <h1>Android containers<br/>in the cloud</h1>
       <p class="u-sv2">Anbox Cloud lets you stream mobile apps securely, at any scale, to any device letting you focus on your apps. Run Android in system containers, not emulators, on AWS, OCI, Azure, GCP or your private cloud.</p>
-      <p><a href="/contact-us" class="p-button--positive">Get Anbox Cloud</a></p>
+      <p><a href="#run-andriod" class="p-button--positive">Get Anbox Cloud</a></p>
     </div>
     <div class="col-6 u-align--cente">
       <div class="u-embedded-media">
@@ -526,7 +526,7 @@
   </div>
 </section>
 
-<section class="p-strip">
+<section class="p-strip" id="run-andriod">
   <div class="row">
     <div class="col-5">
       <h2 class="u-sv3">Run Android in the cloud with Anbox cloud</h2>


### PR DESCRIPTION
## Done

Add id to a section and connect CTA to the hash URL

## QA

- Click `Get Anbox Cloud` CTA and check the page goes to `#run-android and displays the right section
- Refer to this issue to review - https://github.com/canonical-web-and-design/web-squad/issues/5606

## Issue / Card

Fixes [#5606](https://github.com/canonical-web-and-design/web-squad/issues/5606)

