### PR TITLE
fix(search): ignore header and footer in search index, fixes #265

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Thumbs.db
 .LSOverride
 .spelling
 .vscode
+.idea
 
 # [cache] Cache and backup
 *.bak

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,0 +1,1 @@
+robots.txt?: "/static/files/robots.txt"

--- a/static/files/robots.txt
+++ b/static/files/robots.txt
@@ -1,0 +1,4 @@
+User-Agent: *
+Disallow: /static/js/modules/global-nav/global-nav.js
+Disallow: /docs/search
+Disallow: /docs/search*

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -83,7 +83,7 @@
     ></noscript>
     <!-- End Google Tag Manager (noscript) -->
     <header id="navigation" class="p-navigation is-dark">
-      <div class="row p-navigation__wrapper">
+      <div class="row p-navigation__wrapper" data-nosnippet>
         <div class="col-12">
           <div class="p-navigation__row">
             <div class="p-navigation__banner">

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,5 +1,5 @@
 <footer class="p-strip">
-  <div class="row">
+  <div class="row" data-nosnippet>
     <div>
       <p>
         Android is a trademark of Google LLC. Anbox Cloud uses assets available through the Android Open Source Project.


### PR DESCRIPTION
## Done
Marked header and footer with `data-nosnippet` attribute to ignore them in Google search index. Should fix #265 