### PR TITLE
fix(templates): link to tutorials instead of AWS

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -597,12 +597,12 @@
                 <span class="p-contextual-menu--left" style="z-index: 10;">
                   <button class="p-button--neutral p-contextual-menu__toggle has-icon" aria-controls="menu-3"
                           aria-expanded="false" aria-haspopup="true">
-                          <span>Deploy on AWS</span><i class="p-icon--chevron-down p-contextual-menu__indicator"></i>
+                          <span>Deploy now</span><i class="p-icon--chevron-down p-contextual-menu__indicator"></i>
                       </button>
                   <span class="p-contextual-menu__dropdown" id="menu-3" aria-hidden="true" >
                     <span class="p-contextual-menu__group">
-                      <a href="https://aws.amazon.com/marketplace/pp/prodview-3lx6xyaapstz4" class="p-contextual-menu__link">on x86</a>
-                      <a href="https://aws.amazon.com/marketplace/pp/prodview-aqmdt52vqs5qk" class="p-contextual-menu__link">on Arm</a>
+                      <a href="https://anbox-cloud.io/docs/howto/install-appliance/aws" class="p-contextual-menu__link">on AWS</a>
+                      <a href="https://anbox-cloud.io/docs/tut/installing-appliance" class="p-contextual-menu__link">on bare metal</a>
                     </span>
                   </span>
                 </span>


### PR DESCRIPTION
## Done

Link to our own tutorials instead of the AWS marketplace listing

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
