### PR TITLE
fix: docs: skip hidden navgroups

### DIFF
--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -73,22 +73,24 @@
               </a>
             </div>
             {% for nav_group in navigation.nav_items %}
-            {% if nav_group.navlink_text %}
-              {% if nav_group.navlink_href %}
-              <h3 class="p-side-navigation__heading--linked">
-                <a class="p-side-navigation__link" href="{{ nav_group.navlink_href }}" {% if nav_group.is_active %}aria-current="page"{% endif %}>
-                  {{ nav_group.navlink_text }}
-                </a>
-              </h3>
-              {% else %}
-                <h3 class="p-side-navigation__heading">{{ nav_group.navlink_text }}</h3>
-              {% endif %}
+	    {% if not nav_group.hidden %}
+	      {% if nav_group.navlink_text %}
+		{% if nav_group.navlink_href %}
+		<h3 class="p-side-navigation__heading--linked">
+		  <a class="p-side-navigation__link" href="{{ nav_group.navlink_href }}" {% if nav_group.is_active %}aria-current="page"{% endif %}>
+		    {{ nav_group.navlink_text }}
+		  </a>
+		</h3>
+		{% else %}
+		  <h3 class="p-side-navigation__heading">{{ nav_group.navlink_text }}</h3>
+		{% endif %}
+	      {% endif %}
+	      {#
+		Use `create_navigation(nav_group.children)` for a default, fully expanded navigation.
+		Use `create_navigation(nav_group.children, expandable=True)` for the nested nav levels to expand only when parent page is active.
+	      #}
+	      {{ create_navigation(nav_group.children, expandable=True) }}
             {% endif %}
-            {#
-              Use `create_navigation(nav_group.children)` for a default, fully expanded navigation.
-              Use `create_navigation(nav_group.children, expandable=True)` for the nested nav levels to expand only when parent page is active.
-            #}
-            {{ create_navigation(nav_group.children, expandable=True) }}
           {% endfor %}
           </div>
         </nav>


### PR DESCRIPTION
## Done

Updated docs template to skip hidden navgroups

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Visit /docs
- Verify there's no black line underneath the sidebar navigation


## Issue / Card

Fixes #

## Screenshots
Before:
![Before](https://github.com/canonical/anbox-cloud.io/assets/246192/de255fc3-f3b4-4eef-b47c-e1117cda01bd)

After:
![After](https://github.com/canonical/anbox-cloud.io/assets/246192/04c2c022-6ed1-4f76-981e-316b4c016a25)


