### PR TITLE
Fix anbox-cloud.io github links

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -15,8 +15,8 @@
         {% if message %}<blockquote><code>{{ message }}</code></blockquote>{% endif %}
         <p>
           Try reloading the page.
-          If the error persists, please note that it may be a <a href="https://github.com/canonical-websites/anbox-cloud.io/issues">known issue</a>.
-          If not, please <a href="https://github.com/canonical-websites/anbox-cloud.io/issues/new">file a new issue</a>.
+          If the error persists, please note that it may be a <a href="https://github.com/canonical/anbox-cloud.io/issues">known issue</a>.
+          If not, please <a href="https://github.com/canonical/anbox-cloud.io/issues/new">file a new issue</a>.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

- replace github.com/canonical-team to github.com/canonical.
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
