### PR TITLE
Remove redundant reset btn in search [WD-8244]

### DIFF
--- a/templates/docs/search.html
+++ b/templates/docs/search.html
@@ -15,7 +15,6 @@
     <div class="row">
       <form class="p-search-box u-no-margin--bottom"  action="/docs/search">
         <input type="search" class="p-search-box__input" name="q" {% if query %} value="{{ query }}"{% endif %} placeholder="Search documentation" required/>
-        <button type="reset" class="p-search-box__reset"><i class="p-icon--close"></i></button>
         <button type="submit" class="p-search-box__button"><i class="p-icon--search"></i></button>
       </form>
     </div>


### PR DESCRIPTION
## Done

- Remove reset btn from search result page's search bar, as it did not have any action associated to it.
This is consistent with other documentation websites of Canonical, like microk8s.io/docs

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
