### PR TITLE
Fix navigation on smaller screens

### DIFF
--- a/static/sass/_settings.scss
+++ b/static/sass/_settings.scss
@@ -4,5 +4,5 @@ $color-accent: $ubuntu-orange;
 $color-suru-start: #2c001e;
 $color-suru-middle: #772953;
 $color-suru-end: #e95420;
-$breakpoint-navigation-threshold: 600px;
+$breakpoint-navigation-threshold: 620px;
 $table-layout-fixed: false;

--- a/static/sass/_settings.scss
+++ b/static/sass/_settings.scss
@@ -4,5 +4,5 @@ $color-accent: $ubuntu-orange;
 $color-suru-start: #2c001e;
 $color-suru-middle: #772953;
 $color-suru-end: #e95420;
-$breakpoint-navigation-threshold: 620px;
+$breakpoint-navigation-threshold: 620px; // keep this in sync with global nav config in base_layout.html
 $table-layout-fixed: false;

--- a/templates/base_layout.html
+++ b/templates/base_layout.html
@@ -97,7 +97,7 @@
     <script src="/static/js/modules/global-nav/global-nav.js"></script>
     <script>
       canonicalGlobalNav.createNav({
-        maxWidth: '72rem',
+        breakpoint: 620 // same as $breakpoint-navigation-threshold in _settings.scss
       });
       cpNs.cookiePolicy();
     </script>

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -47,10 +47,10 @@
   </div>
   {% else %}
   <div class="row">
-    <div class="col-3">
+    <div class="col-3 col-medium-2">
       {{ nav_logo() }}
     </div>
-    <div class="col-9">
+    <div class="col-9 col-medium-4">
       {{ nav_items() }}
     </div>
   </div>


### PR DESCRIPTION
## Done

Fixes top navigation on medium screens (tablets) by properly adjusting breakpoint value, passing it to global nav, and adding medium screen column values.

Before:

<img width="764" alt="image" src="https://github.com/canonical/anbox-cloud.io/assets/83575/ce96b1f1-ab2d-4d86-9f9e-e182bf71e2cf">

After

<img width="630" alt="image" src="https://github.com/canonical/anbox-cloud.io/assets/83575/cd41dba2-8961-4e36-9cda-f53ef30d24f9">


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check if top navigation displays correctly on various screen sizes (from mobile, through tablet, up to desktop)


