### PR TITLE
Fix suru image strip background color 

### DIFF
--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -9,6 +9,7 @@
     @extend %vf-strip;
 
     background-blend-mode: multiply, multiply, normal, normal;
+    background-color: #fff;
     // sass-lint:disable-block no-color-literals
     background-image: linear-gradient(
       to bottom left,


### PR DESCRIPTION
## Done

Fix suru image strip background color

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check first section on home page "Scalable Android in the cloud", the suru triangle on the left should not have a hard line when the image ends as show in #328 


## Issue / Card

Fixes #328

## Screenshots

This fixes the problem mentioned in #328 by changing the background color of the suru image strip back to its white value.

![image](https://github.com/canonical/anbox-cloud.io/assets/1155472/17834961-b514-4401-99bd-f929e2a3dd47)


