### PR TITLE
add a parameter to YT video URL link to prevent unnecessary suggestions

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
     </div>
     <div class="col-6 u-align--cente">
       <div class="u-embedded-media">
-        <iframe title="Scalable Android Cloud with Anbox Cloud" class="u-embedded-media__element" src="https://www.youtube.com/embed/drOCjcDpnng" allowfullscreen=""></iframe>
+        <iframe title="Scalable Android Cloud with Anbox Cloud" class="u-embedded-media__element" src="https://www.youtube.com/embed/drOCjcDpnng?rel=0" allowfullscreen=""></iframe>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

Added a rel=0 parameter to YouTube URL link to prevent videos from other channels to show up in suggestions after the video reaches the end. The solution comes from this [SO thread](https://stackoverflow.com/a/36327162/6379181).


Similar to: https://github.com/canonical/ubuntu.com/pull/13862

## QA

- Check out the demos

- Play the YouTube embedded video on the homepage till the end
Check all the suggestion videos that pop-up and check if all of them come from Canonical YT channel.

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
