### PR TITLE
Add license information in docs footer

### DIFF
--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -30,7 +30,7 @@
               <p>Ubuntu and Canonical are registered trademarks of Canonical&nbsp;Ltd.</p>
             </li>
             <li class="p-list__item--condensed">
-              <p>Anbox Cloud documentation is licensed under the Creative Commons Attribution-Share Alike 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/.</p>
+              <p>Anbox Cloud documentation is licensed under the Creative Commons Attribution-Share Alike 3.0 Unported License. To view a copy of this license, visit <a href="http://creativecommons.org/licenses/by-sa/3.0/" rel="noopener noreferrer" target="_blank">http://creativecommons.org/licenses/by-sa/3.0/</a>.</p>
             </li>
           </ul>
         </div>


### PR DESCRIPTION
## Done

Added Creative Commons license information to docs footer.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
