### PR TITLE
Fix licensing information to align with legal terms

### DIFF
--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -3,7 +3,7 @@
   <div class="l-docs__subgrid">
     <div class="l-docs__sidebar">
       <div class="u-fixed-width">
-        <p>© {{ now.year }} Canonical Ltd.</p>
+        <p>Copyright © {{ now.year }} CC-BY-SA, Canonical Ltd.</p>
       </div>
     </div>
     <div class="l-docs__main">
@@ -28,9 +28,6 @@
             </li>
             <li class="p-list__item--condensed">
               <p>Ubuntu and Canonical are registered trademarks of Canonical&nbsp;Ltd.</p>
-            </li>
-            <li class="p-list__item--condensed">
-              <p>Anbox Cloud documentation is licensed under the Creative Commons Attribution-Share Alike 3.0 Unported License. To view a copy of this license, visit <a href="http://creativecommons.org/licenses/by-sa/3.0/" rel="noopener noreferrer" target="_blank">http://creativecommons.org/licenses/by-sa/3.0/</a>.</p>
             </li>
           </ul>
         </div>

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -3,7 +3,7 @@
   <div class="l-docs__subgrid">
     <div class="l-docs__sidebar">
       <div class="u-fixed-width">
-        <p>Copyright © {{ now.year }} CC-BY-SA, Canonical Ltd.</p>
+        <p>Copyright © {{ now.year }}<br/>CC-BY-SA, Canonical Ltd.</p>
       </div>
     </div>
     <div class="l-docs__main">


### PR DESCRIPTION
## Done

For documenration, updated license information to CC-BY-SA according to terms confirmed with legal team.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]


## Issue / Card

Fixes #

## Screenshots

[if relevant, include a screenshot]
