### PR TITLE
chore: Bump canoncialwebteam.discourse to 5.6.0 & Vanilla to 4.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postcss": "8.4.38",
     "postcss-cli": "11.0.0",
     "sass": "1.77.6",
-    "vanilla-framework": "4.13.0"
+    "vanilla-framework": "4.14.0"
   },
   "devDependencies": {
     "concurrently": "8.2.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 canonicalwebteam.flask-base==1.1.0
-canonicalwebteam.discourse==5.5.0
+canonicalwebteam.discourse==5.6.0
 Flask-OpenID==1.3.0
 requests==2.32.2
 responses==0.24.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1856,10 +1856,10 @@ util@^0.10.3:
   dependencies:
     inherits "2.0.3"
 
-vanilla-framework@4.13.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.13.0.tgz#3901952faf819be42b24d2efc719c73de384a8ab"
-  integrity sha512-mUSJqs56ycxpEZwplTOiy4SfihjWsPiAddnQZ9b0s0ak8mLHVxnJF1aNIpPixPWK/NvhD9jVACn5qa2pGabRMQ==
+vanilla-framework@4.14.0:
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.14.0.tgz#dca425c806462179467030ac30ef496997e2d8cb"
+  integrity sha512-YctHWwH1SbIltBMMVdeiVW1QtxVjaU15jLKiubgVjE9AByuK/EriyZnPQkXtb/+Rwf1mtF24rae+mmG8aFqUJw==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION
## Done

Bump canonicalwebteam.discourse to 5.6.0 and vanilla to 4.14.0

## QA

- Check nothing the changes in vanilla have not broken anything
- Go to docs and hover over a h2 heading, see the [vanilla anchor link](https://vanillaframework.io/docs/patterns/links#anchor-link) works as expected
- Inspect the heading and see there are no trailing numbers on the heading 


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-12934