### PR TITLE
WD-12934 - update canonicalwebteam.discourse to 5.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 canonicalwebteam.flask-base==1.1.0
-canonicalwebteam.discourse==5.6.0
+canonicalwebteam.discourse==5.6.1
 Flask-OpenID==1.3.0
 requests==2.32.2
 responses==0.24.1


### PR DESCRIPTION
## Done

Bump canonicalwebteam.discourse to 5.6.1

## QA

- Check that the changes have not broken anything

## Issue / Card
[WD-12934](https://warthogs.atlassian.net/browse/WD-12934)

[WD-12934]: https://warthogs.atlassian.net/browse/WD-12934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ