### PR TITLE
fix: Remove redundant key in site.yaml

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -11,10 +11,6 @@ env:
       key: google-custom-search-key
       name: google-api
 
-  - name: FLASK_SECRET_KEY
-    secretKeyRef:
-      key: anbox-cloud-io
-      name: secret-keys
 
 production:
   replicas: 5


### PR DESCRIPTION
## Done

- [x] Remove undefined key from site.yaml causing demo build failures.

Error log: 
<img width="1510" alt="Screenshot 2024-10-04 at 10 26 28 PM" src="https://github.com/user-attachments/assets/85e60bee-a1cc-4862-83ae-2c8a7f8460f6">



## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8043/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check if the demo site below is working.
