### PR TITLE
fix(deploy): keep consistency between upload and download artifact actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -31,7 +31,7 @@ jobs:
         run: charmcraft pack -v --project-dir ./charm
 
       - name: Upload charm
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: anbox-cloud-io-charm
           path: ./*.charm
@@ -60,7 +60,7 @@ jobs:
         run: rockcraft pack
 
       - name: Upload Rock
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: anbox-cloud-io-rock
           path: ./*.rock
@@ -72,7 +72,7 @@ jobs:
       image_url: ${{ steps.set_image_url.outputs.image_url }}
     steps:
       - name: Get Rock
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@v4
         with:
           name: anbox-cloud-io-rock
 


### PR DESCRIPTION
## Done

- Fixed the deploy workflow by setting a consistent version between `upload-artifact` and `download-artifact` (the latest for both, as of now). Otherwise, the `publish-image` step of the workflow will fail, because it uses `v4.1.7` for download which is incompatible with `v3` used for the upload. See compatibility notice [here](https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/#compatibility).