### PR TITLE
fix(deploy): use github actions private runners for deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - deploy-private-runners # TODO: to be removed before merging
 
 env:
   CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: true
@@ -106,18 +105,18 @@ jobs:
           export VAULT_ADDR=https://vault.admin.canonical.com:8200
           export TF_VAR_login_approle_role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }}
           export TF_VAR_login_approle_secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }}
-          export VAULT_SECRET_PATH_ROLE=secret/prodstack6/roles/stg-anbox-cloud-io-k8s
+          export VAULT_SECRET_PATH_ROLE=secret/prodstack6/roles/prod-anbox-cloud-io
           export VAULT_SECRET_PATH_COMMON=secret/prodstack6/juju/common
           VAULT_TOKEN=$(vault write -f -field=token auth/approle/login role_id=${TF_VAR_login_approle_role_id} secret_id=${TF_VAR_login_approle_secret_id}) 
           export VAULT_TOKEN
           mkdir -p ~/.local/share/juju
-          vault read -field=controller_config "${VAULT_SECRET_PATH_COMMON}/controllers/juju-controller-35-staging-ps6" | base64 -d > ~/.local/share/juju/controllers.yaml
+          vault read -field=controller_config "${VAULT_SECRET_PATH_COMMON}/controllers/juju-controller-35-production-ps6" | base64 -d > ~/.local/share/juju/controllers.yaml
           USERNAME=$(vault read -field=username "${VAULT_SECRET_PATH_ROLE}/juju")
           PASSWORD=$(vault read -field=password "${VAULT_SECRET_PATH_ROLE}/juju")
-          printf "controllers:\n  juju-controller-35-staging-ps6:\n    user: %s\n    password: %s\n" "$USERNAME" "$PASSWORD" > ~/.local/share/juju/accounts.yaml
+          printf "controllers:\n  juju-controller-35-production-ps6:\n    user: %s\n    password: %s\n" "$USERNAME" "$PASSWORD" > ~/.local/share/juju/accounts.yaml
 
       - name: Deploy Application
         run: |
-          export JUJU_MODEL=admin/stg-anbox-cloud-io-k8s
+          export JUJU_MODEL=admin/prod-anbox-cloud-io
           juju refresh anbox-cloud-io --path ./anbox-cloud-io_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
           juju wait-for application anbox-cloud-io --query='name=="anbox-cloud-io" && (status=="active" || status=="idle")'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - deploy-private-runners # TODO: to be removed before merging
 
 env:
   CHARMCRAFT_ENABLE_EXPERIMENTAL_EXTENSIONS: true
@@ -84,10 +85,39 @@ jobs:
         run: skopeo --insecure-policy copy oci-archive:$(ls *.rock) docker://${{ steps.set_image_url.outputs.image_url }} --dest-creds "canonical:${{ secrets.GITHUB_TOKEN }}"
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
     needs: [pack-charm, publish-image]
     steps:
-      - name: Workflow run ID
-        run : echo ${{ github.run_id }}
-      - name: Image URL
-        run : echo ${{ needs.publish-image.outputs.image_url }}
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: |
+          sudo snap install juju --channel=3.4/stable --classic
+          sudo snap install vault --classic
+
+      - name: Download Charm Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: anbox-cloud-io-charm
+
+      - name: Configure Vault and Juju
+        run: |
+          export VAULT_ADDR=https://vault.admin.canonical.com:8200
+          export TF_VAR_login_approle_role_id=${{ secrets.VAULT_APPROLE_ROLE_ID }}
+          export TF_VAR_login_approle_secret_id=${{ secrets.VAULT_APPROLE_SECRET_ID }}
+          export VAULT_SECRET_PATH_ROLE=secret/prodstack6/roles/stg-anbox-cloud-io-k8s
+          export VAULT_SECRET_PATH_COMMON=secret/prodstack6/juju/common
+          VAULT_TOKEN=$(vault write -f -field=token auth/approle/login role_id=${TF_VAR_login_approle_role_id} secret_id=${TF_VAR_login_approle_secret_id}) 
+          export VAULT_TOKEN
+          mkdir -p ~/.local/share/juju
+          vault read -field=controller_config "${VAULT_SECRET_PATH_COMMON}/controllers/juju-controller-35-staging-ps6" | base64 -d > ~/.local/share/juju/controllers.yaml
+          USERNAME=$(vault read -field=username "${VAULT_SECRET_PATH_ROLE}/juju")
+          PASSWORD=$(vault read -field=password "${VAULT_SECRET_PATH_ROLE}/juju")
+          printf "controllers:\n  juju-controller-35-staging-ps6:\n    user: %s\n    password: %s\n" "$USERNAME" "$PASSWORD" > ~/.local/share/juju/accounts.yaml
+
+      - name: Deploy Application
+        run: |
+          export JUJU_MODEL=admin/stg-anbox-cloud-io-k8s
+          juju refresh anbox-cloud-io --path ./anbox-cloud-io_ubuntu-22.04-amd64.charm --resource flask-app-image=${{ needs.publish-image.outputs.image_url }}
+          juju wait-for application anbox-cloud-io --query='name=="anbox-cloud-io" && (status=="active" || status=="idle")'

--- a/charm/.gitignore
+++ b/charm/.gitignore
@@ -7,4 +7,3 @@ __pycache__/
 *.py[cod]
 .idea
 .vscode/
-lib/

--- a/charm/requirements.txt
+++ b/charm/requirements.txt
@@ -1,1 +1,2 @@
-paas-app-charmer==1.0.4
+ops ~= 2.17
+paas-charm>=1.0,<2

--- a/charm/src/charm.py
+++ b/charm/src/charm.py
@@ -8,12 +8,12 @@ import logging
 import typing
 
 import ops
-import paas_app_charmer.flask
+import paas_charm.flask
 
 logger = logging.getLogger(__name__)
 
 
-class FlaskCharm(paas_app_charmer.flask.Charm):
+class FlaskCharm(paas_charm.flask.Charm):
     """Flask Charm service."""
 
     def __init__(self, *args: typing.Any) -> None:


### PR DESCRIPTION
## Done

- Updated `deploy` workflow to use GH private runners for automatic deployment of changes pushed to main branch to the production and staging anbox-cloud.io websites.