### PR TITLE
fix(docs): keep redirects but point a elements to RTD pages directly

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -28,7 +28,7 @@
           </p>
         </div>
         <div class="p-cta-block">
-          <a href="/docs/howto/install-appliance/landing"
+          <a href="https://documentation.ubuntu.com/anbox-cloud/howto/install-appliance/landing/"
              class="p-button--positive">Try Anbox Cloud</a>
           <a href="https://pages.ubuntu.com/rs/066-EOV-335/images/Anbox Cloud Datasheet.pdf?version=0">Read the Anbox Cloud datasheet&nbsp;&rsaquo;</a>
         </div>
@@ -665,11 +665,11 @@
             <tr class="u-hide--small">
               <th></th>
               <td data-heading="Anbox Cloud Appliance">
-                <a href="/docs/howto/install-appliance/landing"
+                <a href="https://documentation.ubuntu.com/anbox-cloud/howto/install-appliance/landing/"
                    class="p-button--positive">Install now</a>
               </td>
               <td data-heading="Charmed Anbox Cloud">
-                <a href="/docs/howto/install/deploy-juju" class="p-button--positive">Install now</a>
+                <a href="https://documentation.ubuntu.com/anbox-cloud/howto/install/deploy-juju/" class="p-button--positive">Install now</a>
               </td>
               <td data-heading="Fully managed deployment">
                 <a href="/contact-us" class="p-button--positive js-invoke-modal">Contact us</a>

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -17,10 +17,10 @@
 <nav class="p-navigation__nav" aria-label="main-navigation">
   <ul class="p-navigation__items" {% if not is_docs %}style="margin-left: -.75rem;" {% endif %} role="menu">
     <li class="p-navigation__item" role="menuitem">
-      <a href="/docs/howto/install-appliance/landing" class="p-navigation__link">Install</a>
+      <a href="https://documentation.ubuntu.com/anbox-cloud/howto/install-appliance/landing/" class="p-navigation__link">Install</a>
     </li>
-    <li class="p-navigation__item {% if request.path == '/docs' %}is-selected{% endif %}" role="menuitem">
-      <a href="/docs" class="p-navigation__link">Docs</a>
+    <li class="p-navigation__item" role="menuitem">
+      <a href="https://documentation.ubuntu.com/anbox-cloud/" class="p-navigation__link">Docs</a>
     </li>
     <li class="p-navigation__item {% if request.path in ['/resources',] %}is-selected{% endif %}" role="menuitem">
       <a href="https://discourse.ubuntu.com/c/anbox-cloud/" class="p-navigation__link">Forum</a>

--- a/templates/sitemap/sitemap-index.xml
+++ b/templates/sitemap/sitemap-index.xml
@@ -3,7 +3,4 @@
   <sitemap>
     <loc>https://anbox-cloud.io/sitemap-links.xml</loc>
   </sitemap>
-  <sitemap>
-    <loc>https://anbox-cloud.io/docs/sitemap.xml</loc>
-  </sitemap>
 </sitemapindex>


### PR DESCRIPTION
## Done

- Use direct links to RTD in the web pages, instead of the old ones under the `/docs` redirected path.
- Keep redirects as they are, i.e. all previously bookmarked docs links will continue to work.