### PR TITLE
fix(rockcraft) adjust to new filename in build process

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -4,6 +4,29 @@ env:
   SECRET_KEY: insecure_test_key
 
 jobs:
+  build-rock:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+
+    - name: Build Assets
+      run: |
+        yarn install
+        yarn run build
+
+    - name: Setup LXD
+      uses: canonical/setup-lxd@main
+
+    - name: Setup Rockcraft
+      run: sudo snap install rockcraft --classic --channel=latest/edge
+
+    - name: Pack Rock
+      run: rockcraft pack
+
   run-image:
     runs-on: ubuntu-latest
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -21,4 +21,4 @@ parts:
       - flask/app/webapp
       - flask/app/templates
       - flask/app/static
-      - flask/app/redirects.yaml
+      - flask/app/permanent-redirects.yaml


### PR DESCRIPTION
## Done

- adjust to new filename in the rockcraft build process, which [failed previously](https://github.com/canonical/anbox-cloud.io/actions/runs/13944751350/job/39029266971) due to the new redirect file name.
- add pr check to build the rock