### PR TITLE
chore: redirect anbox-cloud.io to canonical.com/anbox-cloud

### DIFF
--- a/permanent-redirects.yaml
+++ b/permanent-redirects.yaml
@@ -2,7 +2,11 @@ robots.txt?: "/static/files/robots.txt"
 
 # Documentation redirects
 # Home page
-/: "https://canonical.com/anbox-cloud"
+/: https://canonical.com/anbox-cloud
+/contact-us: https://canonical.com/anbox-cloud#get-in-touch
+/thank-you: https://canonical.com/anbox-cloud#contact-form-success
+/terms: https://ubuntu.com/legal/terms-and-policies
+/privacy: https://ubuntu.com/legal/data-privacy
 docs/?: https://canonical-anbox-cloud-documentation.readthedocs-hosted.com/en/latest/
 # Tutorials
 docs/tutorial/landing: https://canonical-anbox-cloud-documentation.readthedocs-hosted.com/en/latest/tutorial/landing/

--- a/permanent-redirects.yaml
+++ b/permanent-redirects.yaml
@@ -2,6 +2,7 @@ robots.txt?: "/static/files/robots.txt"
 
 # Documentation redirects
 # Home page
+/: "https://canonical.com/anbox-cloud"
 docs/?: https://canonical-anbox-cloud-documentation.readthedocs-hosted.com/en/latest/
 # Tutorials
 docs/tutorial/landing: https://canonical-anbox-cloud-documentation.readthedocs-hosted.com/en/latest/tutorial/landing/

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -16,7 +16,7 @@ class TestRoutes(unittest.TestCase):
         we should return a 200 status code
         """
 
-        self.assertEqual(self.client.get("/").status_code, 200)
+        self.assertEqual(self.client.get("/").status_code, 301)
 
     def test_thank_you(self):
         """

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -24,7 +24,7 @@ class TestRoutes(unittest.TestCase):
         we should return a 200 status code
         """
 
-        self.assertEqual(self.client.get("/thank-you").status_code, 200)
+        self.assertEqual(self.client.get("/thank-you").status_code, 301)
 
     def test_contact_us(self):
         """
@@ -32,7 +32,7 @@ class TestRoutes(unittest.TestCase):
         we should return a 200 status code
         """
 
-        self.assertEqual(self.client.get("/contact-us").status_code, 200)
+        self.assertEqual(self.client.get("/contact-us").status_code, 301)
 
     def test_not_found(self):
         """
@@ -55,7 +55,7 @@ class TestRoutes(unittest.TestCase):
         we should return a 200 status code
         """
 
-        self.assertEqual(self.client.get("/terms").status_code, 200)
+        self.assertEqual(self.client.get("/terms").status_code, 301)
 
     def test_privacy(self):
         """
@@ -63,7 +63,7 @@ class TestRoutes(unittest.TestCase):
         we should return a 200 status code
         """
 
-        self.assertEqual(self.client.get("/privacy").status_code, 200)
+        self.assertEqual(self.client.get("/privacy").status_code, 301)
 
     def test_docs(self):
         """


### PR DESCRIPTION
## Done

- Added a redirect in permanent redirects

## QA

- View the site in your web browser at: https://anbox-cloud-io-376.demos.haus/
- Verify the root is redirected to canonical.com/anbox-cloud

## Issue / Card

Fixes #[WD-22302](https://warthogs.atlassian.net/browse/WD-22302)


[WD-22302]: https://warthogs.atlassian.net/browse/WD-22302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ